### PR TITLE
Add support for rendering content with Markdown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,11 +28,15 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
+  Max: 20
   Exclude:
     - "spec/system/**/*_spec.rb"
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+RSpec/NotToNot:
+  EnforcedStyle: to_not
 
 RSpec/ReturnFromStub:
   EnforcedStyle: block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Adds support for ingesting Markdown and outputting HTML
+- Adds support for `.erb`-less HTML and Markdown file names while still processing with ERB
+
 ## [0.1.0] - 2022-03-03
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -73,8 +73,36 @@ Browse `./demo/` to see a full site, but here's a breakdown of what goes into a 
 - `build/` – where the HTML is output to & served from locally, don't check this in
 - `content/` – where pages, images, styles, etc. live
     - e.g. `index.html.erb`
+    - e.g. `about.md`
 - `views/` – where page layouts live (to be evaluated)
     - `layout.html.erb` — default HTML page layout
+
+## Content
+
+Soy content lives in the `content/` directory. If the file name ends in `.erb`,
+it'll get run through the Soy renderer for ERB.
+
+Content can be authored in Markdown, which outputs HTML.
+
+HTML and Markdown files don't need the `.erb` file extension, they'll always
+get run through ERB. So that's optional and totally up to you. `.erb` can help
+with syntax highlighting in your editor.
+
+ERB content will be rendered inside the layout specified in
+`views/layout.html.erb`.
+
+ERB is neat because you can use whatever Ruby you want within it. Here's an
+example with Markdown:
+
+``` markdown
+<% @title = "Neat Products Made of Soy" %>
+
+# <%= @title %>
+
+<% ["tofu", "tempeh", "edamame"].each do |product| %>
+- <%= product %>
+<% end %>
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Browse `./demo/` to see a full site, but here's a breakdown of what goes into a 
 Soy content lives in the `content/` directory. If the file name ends in `.erb`,
 it'll get run through the Soy renderer for ERB.
 
-Content can be authored in Markdown, which outputs HTML.
+Content can be authored in Markdown, which outputs HTML. Soy uses
+[Kramdown](https://rubygems.org/gems/kramdown) for Markdown parsing.
 
 HTML and Markdown files don't need the `.erb` file extension, they'll always
 get run through ERB. So that's optional and totally up to you. `.erb` can help

--- a/demo/content/about.html.erb
+++ b/demo/content/about.html.erb
@@ -1,5 +1,0 @@
-<% @page.set(title: "About") %>
-
-<h1><%= @page.title %></h1>
-
-<p>Soy is a static-site generated backed by model data stored in various portable data formats, from Markdown to YAML.</p>

--- a/demo/content/about.md
+++ b/demo/content/about.md
@@ -1,0 +1,10 @@
+<% @page.set(title: "About") %>
+
+# <%= @page.title %>
+
+![Drawn cartoon tofu with eyes and slight smile](/tofu.png)
+
+Soy is a static-site generated backed by model data stored in various portable
+data formats, from Markdown to YAML.
+
+It supports rendering content from Markdown or HTML too.

--- a/lib/soy.rb
+++ b/lib/soy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "soy/builder"
+require_relative "soy/file"
 require_relative "soy/renderer"
 require_relative "soy/server"
 require_relative "soy/version"

--- a/lib/soy/file.rb
+++ b/lib/soy/file.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Soy
+  # Utility class for taking a path to a file and determining what its
+  # capabilities are within Soy
+  class File
+    def initialize(file_path)
+      @file_path = file_path
+    end
+
+    def read
+      ::File.read(@file_path)
+    end
+
+    def rendered_name
+      bare_name = @file_path.split("/").last.split(".").first
+      "#{bare_name}.html"
+    end
+
+    def render_with_erb?
+      @file_path =~ /.erb$/ || markdown? || html?
+    end
+
+    def markdown?
+      @file_path =~ /.(md|markdown)/
+    end
+
+    def html?
+      @file_path =~ /.html/
+    end
+  end
+end

--- a/soy.gemspec
+++ b/soy.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "kramdown", "~> 2.3"
   spec.add_dependency "listen", "~> 3.7"
   spec.add_dependency "puma", "~> 5.6.2"
   spec.add_dependency "rack", "~> 2.2"

--- a/spec/fixtures/site/content/about.md.erb
+++ b/spec/fixtures/site/content/about.md.erb
@@ -1,0 +1,7 @@
+<% @title = "About" %>
+
+# About Soy
+
+Soy is a static site generator.
+
+> Deeply thought provoking quote.

--- a/spec/fixtures/site/content/contact.md
+++ b/spec/fixtures/site/content/contact.md
@@ -1,0 +1,5 @@
+<% @title = "Contact" %>
+
+# <%= @title %>
+
+If you'd like to contact me, please send an encrypted message over TofuMail.

--- a/spec/soy/file_spec.rb
+++ b/spec/soy/file_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Soy::File do
+  describe "#read" do
+    it "reads the file from disk" do
+      path = "path/to/file.html.erb"
+      allow(File).to receive(:read).with(path) { "content" }
+
+      expect(described_class.new(path).read).to eql("content")
+    end
+  end
+
+  describe "#rendered_name" do
+    it "strips away extraneous file types and outputs as HTML" do
+      path = "path/to/file.html.erb"
+
+      expect(described_class.new(path).rendered_name).to eql("file.html")
+    end
+  end
+
+  describe "#render_with_erb?" do
+    it "returns true for files that end with erb" do
+      expect(described_class.new("file.html.erb")).to be_render_with_erb
+      expect(described_class.new("file.md.erb")).to be_render_with_erb
+      expect(described_class.new("file.css.erb")).to be_render_with_erb
+    end
+
+    it "returns false for files that don't end in erb" do
+      expect(described_class.new("file.png")).to_not be_render_with_erb
+      expect(described_class.new("file.css")).to_not be_render_with_erb
+    end
+
+    it "always returns true markdown and HTML files for .erb-less extension support" do
+      expect(described_class.new("file.html")).to be_render_with_erb
+      expect(described_class.new("file.md")).to be_render_with_erb
+      expect(described_class.new("file.markdown")).to be_render_with_erb
+    end
+  end
+
+  describe "#markdown?" do
+    it "returns true for md" do
+      expect(described_class.new("file.md")).to be_markdown
+    end
+
+    it "returns true for markdown" do
+      expect(described_class.new("file.markdown")).to be_markdown
+    end
+
+    it "supports nested extensions" do
+      expect(described_class.new("file.markdown.erb")).to be_markdown
+    end
+
+    it "returns false for anything else" do
+      expect(described_class.new("file.png")).to_not be_markdown
+    end
+  end
+
+  describe "#html?" do
+    it "returns true for html" do
+      expect(described_class.new("file.html")).to be_html
+    end
+
+    it "supports nested extensions" do
+      expect(described_class.new("file.html.erb")).to be_html
+    end
+
+    it "returns false for anything else" do
+      expect(described_class.new("file.png")).to_not be_html
+    end
+  end
+end

--- a/spec/soy/renderer_spec.rb
+++ b/spec/soy/renderer_spec.rb
@@ -3,38 +3,34 @@
 require "spec_helper"
 
 RSpec.describe Soy::Renderer do
+  def file_double(content, markdown: false)
+    instance_double("Soy::File", read: content, markdown?: markdown)
+  end
+
   describe "#render" do
     it "renders the template in the layout" do
-      template = "<h1>Neat Page</h1>"
-      layout = "[Header] <%= yield %>"
+      template = file_double("<h1>Neat Page</h1>")
+      layout = file_double("[Header] <%= yield %>")
       out = described_class.new(template, layout).render
       expect(out).to eql("[Header] <h1>Neat Page</h1>")
     end
 
     it "supports setting template details that render in the layout" do
-      template = "<% @page.set(title: 'Neat Page') %> <h1><%= @page.title %></h1>"
-      layout = "<title><%= @page.title %></title><%= yield %>"
+      template = file_double("<% @page.set(title: 'Neat Page') %> <h1><%= @page.title %></h1>")
+      layout = file_double("<title><%= @page.title %></title><%= yield %>")
       out = described_class.new(template, layout).render
       expect(out).to eql("<title>Neat Page</title> <h1>Neat Page</h1>")
     end
 
     it "strips lines with just whitespace" do
-      template = "\n\n  <% 'hi' %>\n hi\n"
-      out = described_class.new(template).render
-      expect(out).to eql("\n hi\n")
-    end
-
-    context "when layout is not specified" do
-      it "defaults to nil" do
-        template = "<h1>Neat Page</h1>"
-        out = described_class.new(template).render
-        expect(out).to eql("<h1>Neat Page</h1>")
-      end
+      template = file_double("\n\n  <% 'hi' %>\n hi\n")
+      out = described_class.new(template, nil).render
+      expect(out).to eql(" hi\n")
     end
 
     context "when layout is nil" do
       it "still renders the template" do
-        template = "<h1>Neat Page</h1>"
+        template = file_double("<h1>Neat Page</h1>")
         out = described_class.new(template, nil).render
         expect(out).to eql("<h1>Neat Page</h1>")
       end
@@ -42,10 +38,25 @@ RSpec.describe Soy::Renderer do
 
     context "when the template does not yield" do
       it "just renders the layout" do
-        template = "<h1>Neat Page</h1>"
-        layout = "[Header]"
+        template = file_double("<h1>Neat Page</h1>")
+        layout = file_double("[Header]")
         out = described_class.new(template, layout).render
         expect(out).to eql("[Header]")
+      end
+    end
+
+    context "when the template is a markdown file" do
+      it "converts the markdown to HTML through ERB" do
+        template = file_double("<% @title = 'Neat Page' %>\n# <%= @title %>\n\nSo much to say!\n", markdown: true)
+
+        out = described_class.new(template, nil).render
+        expect(out).to eql(
+          <<~HTML
+            <h1 id="neat-page">Neat Page</h1>
+
+            <p>So much to say!</p>
+          HTML
+        )
       end
     end
   end

--- a/spec/soy_spec.rb
+++ b/spec/soy_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Soy do
   it "has a version number" do
-    expect(Soy::VERSION).not_to be_nil
+    expect(Soy::VERSION).to_not be_nil
   end
 
   describe ".new_site" do

--- a/spec/system/cli/build_spec.rb
+++ b/spec/system/cli/build_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "soy build" do
     expect(cmd_output).to match(/Building site/)
     expect(cmd_output).to match(/built in \d.\d+ seconds/)
 
-    html_output = <<~HTML
+    html_index_output = <<~HTML
       <html>
         <head>
           <title>Hello, world!</title>
@@ -28,9 +28,52 @@ RSpec.describe "soy build" do
       </html>
     HTML
 
-    expect(File.read("#{build_dir}/index.html")).to eql(html_output)
+    expect(File.read("#{build_dir}/index.html")).to eql(html_index_output)
 
-    expect(Dir.glob("#{build_dir}/**")).to eql(["#{build_dir}/image.png", "#{build_dir}/index.html"])
+    html_about_output = <<~HTML
+      <html>
+        <head>
+          <title>About</title>
+        </head>
+        <body>
+
+      <h1 id="about-soy">About Soy</h1>
+
+      <p>Soy is a static site generator.</p>
+
+      <blockquote>
+        <p>Deeply thought provoking quote.</p>
+      </blockquote>
+
+        </body>
+      </html>
+    HTML
+
+    expect(File.read("#{build_dir}/about.html")).to eql(html_about_output)
+
+    html_contact_output = <<~HTML
+      <html>
+        <head>
+          <title>Contact</title>
+        </head>
+        <body>
+
+      <h1 id="contact">Contact</h1>
+
+      <p>If you’d like to contact me, please send an encrypted message over TofuMail.</p>
+
+        </body>
+      </html>
+    HTML
+
+    expect(File.read("#{build_dir}/contact.html")).to eql(html_contact_output)
+
+    expect(Dir.glob("#{build_dir}/**")).to contain_exactly(
+      "#{build_dir}/image.png",
+      "#{build_dir}/about.html",
+      "#{build_dir}/contact.html",
+      "#{build_dir}/index.html"
+    )
   end
 
   it "supports the b alias" do


### PR DESCRIPTION
Includes some quality of life stuff like optional `.erb` extension for
HTML and Markdown files.

I chose Kramdown because it's well supported, pure Ruby, and has minimal
dependencies.
